### PR TITLE
Replace TODO Comment with Xcode Warning

### DIFF
--- a/L10nXcstrings.py
+++ b/L10nXcstrings.py
@@ -117,7 +117,7 @@ def generate_strings(args):
             types = extract_placeholder_types(string_value)
             comment = f"  /// {sanitize_comment(string_value)}"
             if swift_key in unused_keys:
-                comment += " // TODO: Unused"
+                comment = f"  #warning(\"Unused key: {swift_key}\")\n" + comment
             f.write(f"{comment}\n")
             if types:
                 f.write(f"  case {swift_key}({', '.join(types)})\n")

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ l10n-xcstrings
 - Unused keys are marked in the enum like so:
 
 ```
+#warning("Unused key: loginTitle")
 case loginTitle = "login.title" //TODO: Unused
 ```
 


### PR DESCRIPTION
## 📌 Summary

This PR makes a small update to add Xcode warnings in place of TODO comments..

## ✅ Checklist

- [x] I have tested this change locally
- [x] The code builds without errors

## 💬 Notes

<img width="1266" alt="image" src="https://github.com/user-attachments/assets/4833d8ef-f3e7-49f5-8773-8f117df56422" />
