### PR TITLE
Improve placeholder and key detection

### DIFF
--- a/L10nXcstrings.py
+++ b/L10nXcstrings.py
@@ -20,31 +20,33 @@ def get_keys_and_strings_from_xcstrings(path):
     return result
 
 def extract_placeholder_types(string_value: str) -> list[str]:
-    pattern = r'%(\d+\$)?[+\-#0 ]*(?:\d+)?(?:\.\d+)?[hlL]?([@diufFeEgGxXoscp])'
+    pattern = r'%(\d+\$)?[+\-#0 ]*(?:\d+)?(?:\.\d+)?([hlL]?)([@diufFeEgGxXoscp])'
     matches = list(re.finditer(pattern, string_value))
 
     positionals = {}
     order = []
 
-    def swift_type(spec):
-        if spec in {'d', 'i'}:
+    def swift_type(length, spec):
+        if length == 'l' and spec in {'d', 'i'}:
+            return 'Int64'
+        elif length == 'l' and spec == 'u':
+            return 'UInt64'
+        elif spec in {'d', 'i'}:
             return 'Int'
-        elif spec in {'u'}:
+        elif spec == 'u':
             return 'UInt'
         elif spec in {'f', 'F', 'e', 'E', 'g', 'G'}:
             return 'Double'
-        elif spec in {'@'}:
+        elif spec == '@':
             return 'String'
-        elif spec in {'c'}:
+        elif spec == 'c':
             return 'Character'
-        elif spec in {'li', 'ld'}:
-            return 'Int64'
         else:
             return 'CVarArg'
 
     for idx, match in enumerate(matches):
-        pos, spec = match.groups()
-        typ = swift_type(spec)
+        pos, length, spec = match.groups()
+        typ = swift_type(length, spec)
 
         if pos:
             index = int(pos[:-1]) - 1
@@ -71,7 +73,7 @@ def find_used_keys_in_code(source_dir, keys, enum_name, ignore_dirs):
                 with open(os.path.join(root, file), "r", encoding="utf-8") as f:
                     content = f.read()
                     matches = pattern.findall(content)
-                    used_keys.update(matches)
+                    used_keys.update(m for m in matches if m in keys)
 
     return used_keys
 
@@ -94,7 +96,7 @@ def find_unused_keys(args, swiftified_keys):
     return unused
 
 def sanitize_comment(text):
-        return ' '.join(text.strip().splitlines())
+    return ' '.join(text.strip().splitlines())
 
 def generate_strings(args):
     keys_and_strings = get_keys_and_strings_from_xcstrings(args.input)

--- a/tests/test_l10n.py
+++ b/tests/test_l10n.py
@@ -40,7 +40,7 @@ class TestL10nXcstrings(unittest.TestCase):
         mock_walk.return_value = [
             ("/mock_dir", ["subdir"], ["file1.swift"]),
         ]
-        mock_file_content = "L10n.key1 L10n.key2"
+        mock_file_content = "L10n.key1 L10n.key2 L10n.other"
         with patch("builtins.open", mock_open(read_data=mock_file_content)):
             result = find_used_keys_in_code(
                 "/mock_dir", {"key1", "key2", "key3"}, "L10n", []
@@ -86,6 +86,11 @@ class TestL10nXcstrings(unittest.TestCase):
     def test_extract_placeholder_types_edge_cases(self):
         self.assertEqual(extract_placeholder_types("No placeholders"), [])
         self.assertEqual(extract_placeholder_types("%@ and %d"), ["String", "Int"])
+
+    def test_extract_placeholder_types_int64(self):
+        string_value = "Values %ld and %lu"
+        result = extract_placeholder_types(string_value)
+        self.assertEqual(result, ["Int64", "UInt64"])
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- correctly detect Int64/UInt64 specifiers in placeholders
- filter Swift enum key usage to only known keys
- tidy sanitize_comment indentation and tests

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689b0cb2092c833181d20d40da6fa867